### PR TITLE
Switch To Installing pip Deps Before Postgres Tsks

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,6 +15,17 @@
     - libldap2-dev
     - libmysqlclient-dev
 
+- name: Install dependent pip libraries
+  pip:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - setuptools
+    - pip
+    - psycopg2-binary
+    - mysql
+    - Flask-OAuthlib
+
 - postgresql_db:
     name: "{{ superset_postgres_db_name }}"
   tags: [ database ]
@@ -30,17 +41,6 @@
 
 - name: Create superset user.
   user: name={{ superset_user }} group={{ superset_group }} shell=/sbin/nologin
-
-- name: Install dependent pip libraries
-  pip:
-    name: "{{ item }}"
-    state: latest
-  with_items:
-    - setuptools
-    - pip
-    - psycopg2-binary
-    - mysql
-    - Flask-OAuthlib
 
 - name: Install superset
   pip:


### PR DESCRIPTION
Switch to installing pip dependencies before running postgresql_* module
tasks since these modules (postgresql_db and postgresql_user) depend on
one of the pip packages (psycopg2-binary).

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>