### PR TITLE
Fixes CSV Upload Fuctionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ superset_logo_base64: "base64 encoded logo"
 superset_2x_logo_base64: "base64 encoded 2x logo"
 ```
 
+### Asset Uploads
+
+Superset, by default, will activate the following extensions for data uploads:
+
+```yml
+superset_allowed_extensions:
+  - csv
+```
+
+Check the `ALLOWED_EXTENSIONS` configuration in Superset's [config.py](https://github.com/apache/incubator-superset/blob/master/superset/config.py) for the list of supported extensions.
+
+The upload directories for images and data files (to be used by data import extensions) are set to:
+
+```yml
+superset_img_upload_dir: "{{ superset_user_home }}/images/"
+superset_upload_dir: "{{ superset_user_home }}/uploads/"
+```
+
 ## License
 
 Apache 2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,9 @@ superset_languages:
       flag: jp
       name: Japanese
 
+# system user
+superset_user_home: /home/superset
+
 # web UI details
 superset_username: admin
 superset_firstname: Superset
@@ -39,6 +42,8 @@ superset_flask_secret_key: REPLACEalhD4LIU4Ssn6
 superset_port: 8888
 superset_workers: 2
 superset_mapbox_api_key: REPLACE
+superset_allowed_extensions:
+  - csv
 
 # database credentials
 superset_postgres_db_host: localhost
@@ -75,3 +80,7 @@ superset_2x_logo_path:
 superset_app_name: "Superset"
 superset_postgres_login_user: "postgres"
 superset_postgres_login_password: ""
+
+# upload directories
+superset_upload_dir: "{{ superset_user_home }}/uploads/"
+superset_img_upload_dir: "{{ superset_user_home }}/images/"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -75,3 +75,14 @@
     version: "{{ superset_version }}"
     virtualenv: "{{ superset_virtualenv_path }}"
     virtualenv_python: "{{ superset_python_executable }}"
+
+- name: Make sure the superset upload directories exists
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+    owner: "{{ superset_user }}"
+    group: "{{ superset_group }}"
+  with_items:
+    - "{{ superset_img_upload_dir }}"
+    - "{{ superset_upload_dir }}"

--- a/templates/config.py.j2
+++ b/templates/config.py.j2
@@ -194,10 +194,10 @@ LANGUAGES = {
 # Image and file configuration
 # ---------------------------------------------------
 # The file upload folder, when using models with files
-UPLOAD_FOLDER = BASE_DIR + '/app/static/uploads/'
+UPLOAD_FOLDER = "{{ superset_upload_dir }}"
 
 # The image upload folder, when using models with images
-IMG_UPLOAD_FOLDER = BASE_DIR + '/app/static/uploads/'
+IMG_UPLOAD_FOLDER = "{{ superset_img_upload_dir }}"
 
 # The image upload url, when using models with images
 IMG_UPLOAD_URL = '/static/uploads/'
@@ -386,3 +386,8 @@ try:
             superset_config.__file__))
 except ImportError:
     pass
+
+{% if superset_allowed_extensions is defined and superset_allowed_extensions|length > 0 %}
+# Allowed format types for upload on Database view
+ALLOWED_EXTENSIONS = set(['{{ superset_allowed_extensions|join("', '") }}'])
+{% endif %}


### PR DESCRIPTION
Fixes the CSV upload functionality by:
- Adding an Ansible var for specifying the upload dir path
- Making sure the upload dir exists and is owned by the Superset user
- Adding an Ansible var for specifying what Superset extensions are
enabled. By default enable the 'csv' extension

Fixes #11

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>