### PR TITLE
Adds Support for Superset 0.28.1 And Over

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ By default this installs Superset version 0.24. To install a different version, 
 
 ## Role Variables
 
+`superset_python_executable`: Specifies which Python binary to use to install Superset. The role currently supports `python2.7` and `python3.6`.
+`superset_recreate_virtualenv`: Set to `True` if you'd like the role to recreate the Python virtualenv Superset is installed.
+
 ### Other Default variables are listed below
 
 ```yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 # the pip version of superset to deploy
 superset_version: 0.24
 
+# the python executable to install superset using
+superset_python_executable: "python2.7"
+
 # the application secret key
 superset_secret_key: REPLACE\2\1thisismyscretkey\1\2\e\y\y\h
 
@@ -30,6 +33,7 @@ superset_email: techops+superset@ona.io
 superset_pass: REPLACEaVnwiLmc489m13
 
 # web application configuration
+superset_recreate_virtualenv: False
 superset_app: superset
 superset_flask_secret_key: REPLACEalhD4LIU4Ssn6
 superset_port: 8888

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,13 +1,13 @@
 - name: "Set superset config configured."
-  template: src=config.py.j2 dest={{ superset_python_path }}/dist-packages/superset/config.py
+  template: src=config.py.j2 dest={{ superset_python_path }}/site-packages/superset/config.py
   notify:
     - restart superset
 
 - name: Create an admin user.
-  shell: fabmanager create-admin --app {{ superset_app }} --username {{ superset_username }} --firstname {{ superset_firstname }}  --lastname {{ superset_lastname }}  --email {{ superset_email }} --password {{ superset_pass }}
+  shell: "{{ superset_virtualenv_path }}/bin/fabmanager create-admin --app {{ superset_app }} --username {{ superset_username }} --firstname {{ superset_firstname }}  --lastname {{ superset_lastname }}  --email {{ superset_email }} --password {{ superset_pass }}"
 
 - name: Superset init.
-  shell: superset db upgrade && superset load_examples && superset init
+  shell: "{{ superset_virtualenv_path }}/bin/superset db upgrade && {{ superset_virtualenv_path }}/bin/superset load_examples && {{ superset_virtualenv_path }}/bin/superset init"
 
 - name: Create superset systemd service
   template:

--- a/tasks/install-python2.7.yml
+++ b/tasks/install-python2.7.yml
@@ -1,0 +1,9 @@
+---
+- name: Ensure dependencies are installed
+  apt:
+    pkg: "{{ item }}"
+    state: latest
+    update_cache: yes
+  with_items:
+    - python-pip
+    - python-dev

--- a/tasks/install-python3.6.yml
+++ b/tasks/install-python3.6.yml
@@ -1,0 +1,20 @@
+---
+- name: Add a Python 3.6 PPA
+  apt_repository:
+    repo: "ppa:jonathonf/python-3.6"
+    state: present
+
+- name: Ensure dependencies are installed
+  apt:
+    pkg: "{{ item }}"
+    state: latest
+    update_cache: yes
+  with_items:
+    - python3.6
+    - python3.6-dev
+    - python3-pip
+
+- name: Install virtualenv via pip
+  pip:
+    name: virtualenv
+    executable: pip3

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,18 @@
 ---
+- name: Create superset group.
+  group:
+    name: "{{ superset_group }}"
+
+- name: Create superset user.
+  user:
+    name: "{{ superset_user }}"
+    group: "{{ superset_group }}"
+    shell: "{{ superset_shell }}"
+    home: "{{ superset_home }}"
+    create_home: yes
+
+- include_tasks: "install-{{ superset_python_executable }}.yml"
+
 - name: Ensure dependencies are installed
   apt:
     pkg: "{{ item }}"
@@ -9,19 +23,32 @@
     - build-essential
     - libssl-dev
     - libffi-dev
-    - python-dev
-    - python-pip
     - libsasl2-dev
     - libldap2-dev
     - libmysqlclient-dev
+
+- name: Delete the Superset virtualenv directory
+  file:
+    state: absent
+    path: "{{ superset_virtualenv_path }}"
+  when: superset_recreate_virtualenv
+
+- name: Make sure the Superset virtualenv directory exists
+  file:
+    state: directory
+    path: "{{ superset_virtualenv_path }}"
+    owner: "{{ superset_user }}"
+    group: "{{ superset_group }}"
+    recurse: yes
 
 - name: Install dependent pip libraries
   pip:
     name: "{{ item }}"
     state: latest
+    virtualenv: "{{ superset_virtualenv_path }}"
+    virtualenv_python: "{{ superset_python_executable }}"
   with_items:
     - setuptools
-    - pip
     - psycopg2-binary
     - mysql
     - Flask-OAuthlib
@@ -36,13 +63,9 @@
     password: "{{ superset_postgres_db_pass }}"
   tags: [ database ]
 
-- name: Create superset group.
-  group: name={{ superset_group }}
-
-- name: Create superset user.
-  user: name={{ superset_user }} group={{ superset_group }} shell=/sbin/nologin
-
 - name: Install superset
   pip:
     name: superset
     version: "{{ superset_version }}"
+    virtualenv: "{{ superset_virtualenv_path }}"
+    virtualenv_python: "{{ superset_python_executable }}"

--- a/tasks/white-label.yml
+++ b/tasks/white-label.yml
@@ -2,7 +2,7 @@
 - name: Copy superset branding images.
   copy:
     src: "files/{{ item }}"
-    dest: "{{ superset_python_path }}/dist-packages/superset/static/assets/images/{{ item }}"
+    dest: "{{ superset_python_path }}/site-packages/superset/static/assets/images/{{ item }}"
   with_items:
     - "{{ superset_favicon_path }}"
     - "{{ superset_logo_path }}"
@@ -10,15 +10,15 @@
   when: superset_white_label_use_filepaths == True
 
 - name: Decode and set up base64 encoded favicon
-  shell: echo {{ superset_favicon_base64 }} | base64 -d > "{{ superset_python_path }}/dist-packages/superset/static/assets/images/s.png"
+  shell: echo {{ superset_favicon_base64 }} | base64 -d > "{{ superset_python_path }}/site-packages/superset/static/assets/images/s.png"
   when: superset_white_label_use_base64 == True
 
 - name: Decode and set up base64 encoded logo
-  shell: echo {{ superset_logo_base64 }} | base64 -d > "{{ superset_python_path }}/dist-packages/superset/static/assets/images/superset.png"
+  shell: echo {{ superset_logo_base64 }} | base64 -d > "{{ superset_python_path }}/site-packages/superset/static/assets/images/superset.png"
   when: superset_white_label_use_base64 == True
 
 - name: Decode and set up base64 encoded @2x logo
-  shell: echo {{ superset_2x_logo_base64 }} | base64 -d > "{{ superset_python_path }}/dist-packages/superset/static/assets/images/superset-logo@2x.png"
+  shell: echo {{ superset_2x_logo_base64 }} | base64 -d > "{{ superset_python_path }}/site-packages/superset/static/assets/images/superset-logo@2x.png"
   when: superset_white_label_use_base64 == True
 
 - name: Ensure Superset is restarted

--- a/templates/superset.service.j2
+++ b/templates/superset.service.j2
@@ -8,9 +8,10 @@ After=network.target
 Environment="{{ key }}={{ value }}"
 {% endfor %}
 {% endif %}
+Environment="PATH={{ superset_virtualenv_path }}/bin:$PATH"
 User={{ superset_user }}
 Type=simple
-ExecStart=/usr/local/bin/superset runserver -p {{ superset_port }} -w {{ superset_workers }}
+ExecStart={{ superset_virtualenv_path }}/bin/superset runserver -p {{ superset_port }} -w {{ superset_workers }}
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 KillSignal=SIGINT

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,7 @@
-superset_virtualenv: superset
+superset_virtualenv_path: "{{ superset_home }}/.virtualenvs/{{ superset_user }}"
+superset_home: "/home/{{ superset_user }}"
+superset_shell: "/sbin/nologin"
 superset_group: superset
 superset_user: superset
 superset_service: /etc/systemd/system/superset.service
-superset_python_path: /usr/local/lib/python2.7
+superset_python_path: "{{ superset_virtualenv_path }}/lib/{{ superset_python_executable }}"


### PR DESCRIPTION
Superset version 0.28.1 requires Python 3.6. Add support for this.
Switch to installing the pip packages in a virtualenv to allow for
cleaner upgrades.

Role will support installing Superset using either Python 2.7 or Python
3.6.

Related to apache/incubator-superset#6243

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>