### PR TITLE
Removes Redundant superset_user_home

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Check the `ALLOWED_EXTENSIONS` configuration in Superset's [config.py](https://g
 The upload directories for images and data files (to be used by data import extensions) are set to:
 
 ```yml
-superset_img_upload_dir: "{{ superset_user_home }}/images/"
-superset_upload_dir: "{{ superset_user_home }}/uploads/"
+superset_img_upload_dir: "{{ superset_home }}/images/"
+superset_upload_dir: "{{ superset_home }}/uploads/"
 ```
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,9 +25,6 @@ superset_languages:
       flag: jp
       name: Japanese
 
-# system user
-superset_user_home: /home/superset
-
 # web UI details
 superset_username: admin
 superset_firstname: Superset
@@ -82,5 +79,5 @@ superset_postgres_login_user: "postgres"
 superset_postgres_login_password: ""
 
 # upload directories
-superset_upload_dir: "{{ superset_user_home }}/uploads/"
-superset_img_upload_dir: "{{ superset_user_home }}/images/"
+superset_upload_dir: "{{ superset_home }}/uploads/"
+superset_img_upload_dir: "{{ superset_home }}/images/"


### PR DESCRIPTION
There's already a variable used for setting the Superset user's home
directory (superset_home). Remove the redundant superset_user_home.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>