### PR TITLE
Add ability to install superset from git

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,10 @@
 # the pip version of superset to deploy
 superset_version: 0.28.1
 
+# installation options
+superset_install_from_git: false
+superset_git_url: https://github.com/apache/incubator-superset.git
+
 # the python executable to install superset using
 superset_python_executable: "python3.6"
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -82,7 +82,7 @@
     login_password: "{{ superset_postgres_login_password }}"
   tags: [ database ]
 
-- name: Install superset
+- name: Install superset from pypi
   become: true
   become_user: "{{ superset_user }}"
   pip:
@@ -90,6 +90,17 @@
     version: "{{ superset_version }}"
     virtualenv: "{{ superset_virtualenv_path }}"
     virtualenv_python: "{{ superset_python_executable }}"
+  when: superset_install_from_git == False
+
+- name: Install superset from git
+  become: true
+  become_user: "{{ superset_user }}"
+  pip:
+    name: 'git+{{ superset_git_url }}@{{ superset_version }}'
+    state: latest
+    virtualenv: "{{ superset_virtualenv_path }}"
+    virtualenv_python: "{{ superset_python_executable }}"
+  when: superset_install_from_git
 
 - name: Install additional packages
   become: true


### PR DESCRIPTION
Some of the superset releases are not on pypi and if we want to be able to install them then we need to get them from Github.  This PR adds the ability to do this.