### PR TITLE
Add support for PATCHUP_EMAIL_BASE

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -144,7 +144,7 @@ superset_add_custom_roles: False
 superset_custom_roles:
 
 # PATCHUP_EMAIL_BASE
-# this is used for oAuth provider's whose users do not have an email address
+# this is used for OAuth providers whose users do not have an email address
 # superset requires an email address and so we need to provide it
 # the email base should be a string e.g. superset@example.com
 # we then use it to construct email addresses for the user logging in

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,3 +142,11 @@ superset_add_custom_roles: False
 #     'ROLE_NAME': {'PERMISSION1', 'PERMISSION2'}
 #   }
 superset_custom_roles:
+
+# PATCHUP_EMAIL_BASE
+# this is used for oAuth provider's whose users do not have an email address
+# superset requires an email address and so we need to provide it
+# the email base should be a string e.g. superset@example.com
+# we then use it to construct email addresses for the user logging in
+# that look like superset+username@example.com (if the base was as set above)
+superset_patchup_email_base:

--- a/templates/superset_python_path/superset_config.py.j2
+++ b/templates/superset_python_path/superset_config.py.j2
@@ -137,6 +137,11 @@ ADD_CUSTOM_ROLES = {{ superset_add_custom_roles }}
 CUSTOM_ROLES = {{ superset_custom_roles }}
 {% endif %}
 
+# PATCHUP_EMAIL_BASE
+{% if superset_patchup_email_base %}
+PATCHUP_EMAIL_BASE = {{ superset_patchup_email_base }}
+{% endif %}
+
 {% if superset_allowed_extensions is defined and superset_allowed_extensions|length > 0 %}
 # Allowed format types for upload on Database view
 ALLOWED_EXTENSIONS = set(['{{ superset_allowed_extensions|join("', '") }}'])


### PR DESCRIPTION
This is  a [new Superset setting added by Ketchup](https://github.com/onaio/superset-patchup/pull/26/commits/c406c12ce555979978c2d3c28a87b81f21879d20) and used for oAuth provider's
whose users do not have an email address superset requires an
email address and so we need to provide it the email base should
be a string e.g. superset@example.com we then use it to construct
email addresses for the user logging in that look like
superset+username@example.com (if the base was as set above)