### PR TITLE
Make Logging Into PostgreSQL Optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,6 +89,10 @@ superset_favicon_path:
 superset_logo_path:
 superset_2x_logo_path:
 superset_app_name: "Superset"
+# Set to true if you'd want the role to login to PostgreSQL using the provided
+# credentials instead as using the default authentication mechanism (sudo'ing to
+# the prostgres user)
+superset_postgres_login: true
 superset_postgres_login_user: "postgres"
 superset_postgres_login_password: ""
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -63,24 +63,41 @@
     virtualenv_python: "{{ superset_python_executable }}"
   when: superset_enable_cors
 
-- name: Create postgres database
-  postgresql_db:
-    name: "{{ superset_postgres_db_name }}"
-    login_host: "{{ superset_postgres_db_host }}"
-    login_user: "{{ superset_postgres_login_user }}"
-    login_password: "{{ superset_postgres_login_password }}"
-  tags: [ database ]
+- block:
+  - name: Create postgres database
+    postgresql_db:
+      name: "{{ superset_postgres_db_name }}"
+      login_host: "{{ superset_postgres_db_host }}"
+      login_user: "{{ superset_postgres_login_user }}"
+      login_password: "{{ superset_postgres_login_password }}"
+    tags: [ database ]
 
-- name: Create postgres user
-  postgresql_user:
-    name: "{{ superset_postgres_db_user }}"
-    password: "{{ superset_postgres_db_pass }}"
-    encrypted: true
-    db: "{{ superset_postgres_db_name }}"
-    login_host: "{{ superset_postgres_db_host }}"
-    login_user: "{{ superset_postgres_login_user }}"
-    login_password: "{{ superset_postgres_login_password }}"
-  tags: [ database ]
+  - name: Create postgres user
+    postgresql_user:
+      name: "{{ superset_postgres_db_user }}"
+      password: "{{ superset_postgres_db_pass }}"
+      encrypted: true
+      db: "{{ superset_postgres_db_name }}"
+      login_host: "{{ superset_postgres_db_host }}"
+      login_user: "{{ superset_postgres_login_user }}"
+      login_password: "{{ superset_postgres_login_password }}"
+    tags: [ database ]
+  when: superset_postgres_login == true
+
+- block:
+  - name: Create postgres database
+    postgresql_db:
+      name: "{{ superset_postgres_db_name }}"
+    tags: [ database ]
+
+  - name: Create postgres user
+    postgresql_user:
+      name: "{{ superset_postgres_db_user }}"
+      password: "{{ superset_postgres_db_pass }}"
+      encrypted: true
+      db: "{{ superset_postgres_db_name }}"
+    tags: [ database ]
+  when: superset_postgres_login == false
 
 - name: Install superset from pypi
   become: true


### PR DESCRIPTION
Since by default the PostgreSQL modules authenticate by trying to su
as the postgres user, make providing login credentials optional.

A Superset deployment using this role was deployed this way before
support for logging in was added.

Signed-off-by: Jason Rogena <jason@rogena.me>