### PR TITLE
Make Initializing CUSTOM_ROLES Optional

### DIFF
--- a/templates/superset_python_path/superset_config.py.j2
+++ b/templates/superset_python_path/superset_config.py.j2
@@ -132,7 +132,9 @@ ENABLE_PROXY_FIX = {{ superset_enable_proxy_fix }}
 
 # Add custom roles
 ADD_CUSTOM_ROLES = {{ superset_add_custom_roles }}
+{% if superset_add_custom_roles %}
 CUSTOM_ROLES = {{ superset_custom_roles }}
+{% endif %}
 
 {% if superset_allowed_extensions is defined and superset_allowed_extensions|length > 0 %}
 # Allowed format types for upload on Database view


### PR DESCRIPTION
The CUSTOM_ROLES variable needs only to be initialized when
superset_add_custom_roles is set to true. Otherwise, if variable is set
to an empty string (because no custom roles need to be declared)
Superset errors.

Co-authored-by: Kelvin Jayanoris <kelvin@jayanoris.com>
Signed-off-by: Jason Rogena <jason@rogena.me>