### PR TITLE
Add Python3-setuptools to System Dependencies

### DIFF
--- a/tasks/install-python3.6.yml
+++ b/tasks/install-python3.6.yml
@@ -6,13 +6,12 @@
 
 - name: Ensure dependencies are installed
   apt:
-    pkg: ["python3.6", "python3.6-dev", "python3-pip"]
+    pkg: ["python3.6", "python3.6-dev", "python3-pip", "python3-setuptools"]
     state: latest
     update_cache: yes
 
 - name: Install virtualenv via pip
   pip:
     name: virtualenv
-    executable: pip3
+    virtualenv_python: "{{ superset_python_executable }}"
     state: latest
-


### PR DESCRIPTION
Creating a python3 virtualenv fails without setuptools. Adding the setuptools as part of the system dependencies before creating the virtualenv fixes the problem.