### PR TITLE
Default superset robot permission roles

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -188,3 +188,6 @@ superset_celerybeat_schedule: |
 
 superset_apt_dependencies_packages: ["build-essential", "libssl-dev", "libffi-dev", "libsasl2-dev", "libldap2-dev", "libmysqlclient-dev", "python-pip", "python-psycopg2", "libpq-dev"]
 superset_pip_dependencies_packages: ["setuptools", "psycopg2-binary", "mysql", "Flask-OAuthlib", "crontab"]
+
+# Roles created by superset
+superset_robot_permission_roles: ['Public', 'Gamma', 'Alpha', 'Admin', 'sql_lab']

--- a/templates/superset_python_path/superset_config.py.j2
+++ b/templates/superset_python_path/superset_config.py.j2
@@ -149,3 +149,7 @@ CACHE_CONFIG = {{ superset_cache_config }}
 import crontab
 CELERYBEAT_SCHEDULE = {{ superset_celerybeat_schedule }}
 {% endif %}
+
+# Roles that are controlled by the API / Superset and should not be changes
+# by humans.
+ROBOT_PERMISSION_ROLES = {{ superset_robot_permission_roles }}


### PR DESCRIPTION
Set the robot permission roles as a variable to make it configurable for different supersets for example discover.ona.io that has a custom public role
https://github.com/apache/incubator-superset/blob/bd24f854c96390e53bdfb0a3e5c3122928340acf/superset/config.py#L329