### PR TITLE
Set cache default timeout outside cache config to override defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,17 +167,17 @@ Superset-patchup enhances Superset by adding more features.  You can read more a
 > Note that the versions of ansible-superset bindings including this warning are only compatible with superset-patchup v0.1.6 and above (due to changed initialization logic).
 
 ###  Superset caching
-To enable [caching](https://superset.incubator.apache.org/installation.html#caching) in superset, provide `CACHE_CONFIG` that complies with the Flask-Cache specifications.
+To enable [caching](https://superset.incubator.apache.org/installation.html#caching) in superset, provide `CACHE_CONFIG` that complies with the Flask-Cache specifications and `CACHE_DEFAULT_TIMEOUT` that determines the cache warmup period.
 
 ```yml
 superset_enable_cache: True
 superset_cache_config: |
   {
     'CACHE_TYPE': 'redis',
-    'CACHE_DEFAULT_TIMEOUT': 60 * 60 * 24, # 1 day
     'CACHE_KEY_PREFIX': 'superset_results',
     'CACHE_REDIS_URL': 'redis://localhost:6379/0'
   }
+superset_cache_default_timeout: 60 * 60 * 24, # 1 day
 ```
 
 To allow periodical warmup of the cache, configure Superset's celery task with the preferred warmup strategy. Enable celerybeat and configure it's dictionary like so:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -166,10 +166,10 @@ superset_enable_cache: False
 superset_cache_config: |
   {
     'CACHE_TYPE': 'redis',
-    'CACHE_DEFAULT_TIMEOUT': 60 * 60 * 24, # 1 day
     'CACHE_KEY_PREFIX': 'superset_results',
     'CACHE_REDIS_URL': 'redis://localhost:6379/0'
   }
+superset_cache_default_timeout: 60 * 60 * 24, # 1 day
 
 # Configure superset celery task cache warmup
 superset_enable_celerybeat: False

--- a/templates/superset_python_path/superset_config.py.j2
+++ b/templates/superset_python_path/superset_config.py.j2
@@ -142,6 +142,7 @@ superset_patchup.add_ketchup(sys.modules[__name__])
 {% if superset_enable_cache and superset_cache_config %}
 # Superset caching config
 CACHE_CONFIG = {{ superset_cache_config }}
+CACHE_DEFAULT_TIMEOUT = {{ superset_cache_default_timeout }}
 {% endif %}
 
 {% if superset_enable_celerybeat and superset_celerybeat_schedule %}


### PR DESCRIPTION
Fixes https://github.com/onaio/canopy/issues/512

Without defining `CACHE_DEFAULT_TIMEOUT` as a variable on it's own, the default of 24 hours is picked from https://github.com/apache/incubator-superset/blob/master/superset/config.py#L265 therefore this is never overridden https://github.com/apache/incubator-superset/blob/master/superset/config.py#L524