### PR TITLE
Use crontab in superset_config from celery.schedules

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -187,4 +187,4 @@ superset_celerybeat_schedule: |
   }
 
 superset_apt_dependencies_packages: ["build-essential", "libssl-dev", "libffi-dev", "libsasl2-dev", "libldap2-dev", "libmysqlclient-dev", "python-pip", "python-psycopg2", "libpq-dev"]
-superset_pip_dependencies_packages: ["setuptools", "psycopg2-binary", "mysql", "Flask-OAuthlib", "crontab"]
+superset_pip_dependencies_packages: ["setuptools", "psycopg2-binary", "mysql", "Flask-OAuthlib"]

--- a/templates/superset_python_path/superset_config.py.j2
+++ b/templates/superset_python_path/superset_config.py.j2
@@ -146,6 +146,6 @@ CACHE_CONFIG = {{ superset_cache_config }}
 
 {% if superset_enable_celerybeat and superset_celerybeat_schedule %}
 # Superset celery task cache warmup configs
-import crontab
+from celery.schedules import crontab
 CELERYBEAT_SCHEDULE = {{ superset_celerybeat_schedule }}
 {% endif %}


### PR DESCRIPTION
Use the crontab from `celery.schedules` as mentioned in superset config here: https://github.com/erfaan/ansible-superset/blob/master/defaults/main.yml