### PR TITLE
Set PYTHONPATH when configuring Superset

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -17,6 +17,8 @@
   become_user: "{{ superset_user }}"
   command: "{{ superset_virtualenv_path }}/bin/fabmanager create-admin --app {{ superset_app }} --username {{ superset_username }} \
             --firstname {{ superset_firstname }}  --lastname {{ superset_lastname }}  --email {{ superset_email }} --password {{ superset_pass }}"
+  environment:
+    PYTHONPATH: "{{ superset_python_path }}"
   when: not superset_install_from_git|bool and superset_version is version_compare('0.34.0', '<')
 
 - name: Create an admin user(Superset version >= 0.34.0)
@@ -25,6 +27,7 @@
   command: "{{ superset_virtualenv_path }}/bin/flask fab create-admin --username {{ superset_username }} --firstname {{ superset_firstname }} \
             --lastname {{ superset_lastname }}  --email {{ superset_email }} --password {{ superset_pass }}"
   environment:
+    PYTHONPATH: "{{ superset_python_path }}"
     FLASK_APP: "{{ superset_app }}"
   when: superset_install_from_git|bool or superset_version is version_compare('0.34.0', '>=')
 
@@ -32,17 +35,23 @@
   become: true
   become_user: "{{ superset_user }}"
   command: "{{ superset_virtualenv_path }}/bin/superset db upgrade"
+  environment:
+    PYTHONPATH: "{{ superset_python_path }}"
 
 - name: Load superset examples.
   become: true
   become_user: "{{ superset_user }}"
   command: "{{ superset_virtualenv_path }}/bin/superset load_examples"
+  environment:
+    PYTHONPATH: "{{ superset_python_path }}"
   when: superset_load_examples|bool
 
 - name: Superset init.
   become: true
   become_user: "{{ superset_user }}"
   command: "{{ superset_virtualenv_path }}/bin/superset init"
+  environment:
+    PYTHONPATH: "{{ superset_python_path }}"
 
 - name: Ensure required directories are present
   file:


### PR DESCRIPTION
This is because calling the Superset/Flask commands would otherwise
not use our custom config file.  This is bad because the commands would
not work as expected e.g. they are likely to be run against an SQLite
database (which is Superset's default) instead of the database defined
in our custom config file.

This essentially reverts #548535fa25947048c66021354042dda6b5bfe9ff