### PR TITLE
Add Deadsnakes PPA for Python 3.6

### DIFF
--- a/tasks/install-python3.6.yml
+++ b/tasks/install-python3.6.yml
@@ -1,4 +1,9 @@
 ---
+- name: Add Deadsnakes PPA
+  apt_repository:
+    repo: ppa:deadsnakes/ppa
+  when: ansible_lsb.major_release|int < 18
+
 - name: Ensure dependencies are installed
   apt:
     pkg: ["python3.6", "python3.6-dev", "python3-pip", "python3-setuptools"]


### PR DESCRIPTION
Apt cannot find python 3.6 on Ubuntu 18.0.4. Add Deadsnakes PPA to use to as a source of python3.6