### PR TITLE
Switch to Current User Before Running Compile-Assests Task

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -237,3 +237,4 @@ superset_wsgi_memory_report: False
 superset_local_build_npm_dir: "/usr/bin"
 superset_local_build_npm_args: "--max-old-space-size=1024"
 superset_local_build_directory: "/tmp/{{ lookup('env', 'USER') }}/superset/{{ superset_version }}"
+superset_local_build_user: "{{ lookup('env', 'USER') }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -236,5 +236,5 @@ superset_wsgi_memory_report: False
 # local npm build
 superset_local_build_npm_dir: "/usr/bin"
 superset_local_build_npm_args: "--max-old-space-size=1024"
-superset_local_build_directory: "/tmp/{{ lookup('env', 'USER') }}/superset/{{ superset_version }}"
+superset_local_build_directory: "/tmp/{{ superset_local_build_user }}/superset/{{ superset_version }}"
 superset_local_build_user: "{{ lookup('env', 'USER') }}"

--- a/tasks/compile-assets.yml
+++ b/tasks/compile-assets.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install superset from git
-  become: false
+  become: true
+  become_user: "{{ superset_local_build_user }}"
   git:
     accept_hostkey: "yes"
     repo: "{{ superset_git_url }}"
@@ -10,7 +11,8 @@
   when: superset_install_from_git|bool
 
 - name: Install javascript dependencies
-  become: false
+  become: true
+  become_user: "{{ superset_local_build_user }}"
   npm:
     path: "{{ superset_local_build_directory }}/superset/static/assets"
     executable: "{{ superset_local_build_npm_dir }}/npm"
@@ -20,7 +22,8 @@
   when: superset_install_from_git|bool
 
 - name: Compile javascript
-  become: false
+  become: true
+  become_user: "{{ superset_local_build_user }}"
   command: "{{ superset_local_build_npm_dir }}/npm run build {{ superset_local_build_npm_args }}"
   args:
     chdir: "{{ superset_local_build_directory }}/superset/static/assets"
@@ -30,7 +33,8 @@
   when: superset_install_from_git|bool
 
 - name: Compress dist directory
-  become: false
+  become: true
+  become_user: "{{ superset_local_build_user }}"
   archive:
     path: "{{ superset_local_build_directory }}/superset/static/assets/dist"
     dest: "{{ superset_local_build_directory }}/superset/static/assets/dist.tgz"


### PR DESCRIPTION
Set become to true and define become_user to the current user before running tasks defined in [compile-assets.yml](https://github.com/onaio/ansible-superset/blob/master/tasks/compile-assets.yml)