### PR TITLE
Add superset_compile_assets for optional compilation of assets

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ superset_git_url: https://github.com/apache/incubator-superset.git
 superset_package_name: apache-superset
 superset_start_command: run
 superset_additional_options: --with-threads
+superset_compile_assets: true
 
 # the python executable to install superset using
 superset_python_executable: "python3.6"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,5 +2,6 @@
 - include: install.yml
 - include: config.yml
 - include: compile-assets.yml
+  when: superset_compile_assets|default(false)
 - include: white-label.yml
   when: superset_white_label == True


### PR DESCRIPTION
Superset version 0.36.0 does not seem to have assets that need compilation.